### PR TITLE
fix(i18n): load locale messages under Vite 8

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { isDark } from '~/composables'
 
-const { t } = useI18n()
+const { t, locale } = useI18n()
 const title = computed(() => t('sese.title'))
 
 // https://github.com/vueuse/head
@@ -9,6 +9,10 @@ const title = computed(() => t('sese.title'))
 // they will be rendered correctly in the html results with vite-ssg
 
 useHead({
+  // keep <html lang> in sync with the active locale (fixes hardcoded lang="en")
+  htmlAttrs: {
+    lang: locale,
+  },
   title,
   meta: [
     { name: 'description', content: 'SeSe Engine 是一个轻量级的搜索引擎，可以轻松部署在自己的个人服务器上。' },

--- a/src/modules/i18n.ts
+++ b/src/modules/i18n.ts
@@ -5,13 +5,14 @@ import { createI18n } from 'vue-i18n'
 // https://vitejs.dev/guide/features.html#glob-import
 //
 // Don't need this? Try vitesse-lite: https://github.com/antfu/vitesse-lite
-const messages = Object.fromEntries(
+export const messages = Object.fromEntries(
   Object.entries(
-    import.meta.glob<{ default: any }>('../../locales/*.y(a)?ml', { eager: true }),
+    import.meta.glob<{ default: any }>('../../locales/*.{yml,yaml}', { eager: true }),
   )
     .map(([key, value]) => {
-      const yaml = key.endsWith('.yaml')
-      return [key.slice(14, yaml ? -5 : -4), value.default]
+      // '../../locales/en.yml' -> 'en'
+      const locale = key.slice(key.lastIndexOf('/') + 1).replace(/\.ya?ml$/, '')
+      return [locale, value.default]
     }),
 )
 

--- a/test/i18n.test.ts
+++ b/test/i18n.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { createI18n } from 'vue-i18n'
+import { messages } from '~/modules/i18n'
+
+// Regression guard for the i18n message loading.
+//
+// The locale files are loaded through `import.meta.glob` in
+// `src/modules/i18n.ts`. A wrong glob pattern silently resolves to an empty
+// object, which makes `t()` return the raw key (e.g. `sese.title`) everywhere
+// while the build still succeeds. These tests fail in that scenario.
+describe('i18n messages', () => {
+  it('loads every locale file via glob', () => {
+    const locales = Object.keys(messages)
+    expect(locales).toContain('en')
+    expect(locales).toContain('zh-CN')
+  })
+
+  it('resolves keys to real translations instead of leaking the key', () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: 'zh-CN',
+      fallbackLocale: 'en',
+      messages,
+    })
+    const { t } = i18n.global
+
+    // default locale (zh-CN)
+    expect(t('sese.title')).toBe('Sese 搜索')
+    expect(t('button.toggle_langs')).toBe('切换语言')
+    expect(t('placeholder.search')).toBe('搜索')
+    expect(t('sese.title')).not.toBe('sese.title')
+
+    // switching locale resolves the English messages
+    i18n.global.locale.value = 'en'
+    expect(t('sese.title')).toBe('Sese Search')
+    expect(t('button.toggle_langs')).toBe('Change languages')
+  })
+})


### PR DESCRIPTION
## Problem

The Vite 8 upgrade silently broke i18n. `src/modules/i18n.ts` loaded locales with:

```ts
import.meta.glob('../../locales/*.y(a)?ml', { eager: true })
```

Vite 8's new glob engine no longer matches that `(a)?` extglob, so `messages` resolved to an empty object and **every `t()` call returned its raw key**. The build still exits 0, so CI stayed green while the deployed site rendered `<title>sese.title</title>`, a search button reading `button.search`, `aria-label="placeholder.search"`, etc.

## Fix

- `src/modules/i18n.ts`: use a brace pattern `*.{yml,yaml}` (engine-agnostic) and derive the locale from the filename instead of a fragile fixed-length slice.
- `src/App.vue`: bind `<html lang>` to the active locale — it was hardcoded `en` in `index.html` while the default locale is `zh-CN`.
- `test/i18n.test.ts`: regression test that fails when the message map is empty or keys stop resolving, so this can't silently regress again.

## Verification

`lint`, `typecheck`, `test` (incl. the new i18n test), and `build` all pass. Rebuilt output now renders `<title>Sese 搜索</title>`, translated `aria-label`/`title` attributes, and `<html lang="zh-CN">`; English messages are bundled so the language switcher works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEP5DMkpLUNXC4SBGQxq8i

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEP5DMkpLUNXC4SBGQxq8i)_