### PR TITLE
chore: pin pnpm with integrity hash in packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sese-engine-ui",
   "type": "module",
   "private": true,
-  "packageManager": "pnpm@11.9.0",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "engines": {
     "node": "^20.19.0 || >=22.12.0"
   },


### PR DESCRIPTION
## What

Pin the `packageManager` field with corepack's integrity hash:

```
"packageManager": "pnpm@11.9.0+sha512.bd682d…f03b"
```

## Why

`pnpm@11.9.0` is already the latest pnpm and matches the regenerated `pnpm-lock.yaml` (`lockfileVersion: 9.0`, upgraded from `6.0`/pnpm 8 during the dependency upgrade). Adding the integrity hash makes corepack **verify** the pnpm binary on activation — reproducible installs and supply-chain hardening — which is the form `corepack use` produces.

## Verification

- Hash cross-checked two independent ways: the official npm registry SRI (`dist.integrity`) decoded to the same digest as `sha512sum` of the tarball.
- `corepack pnpm --version` downloaded pnpm 11.9.0 and accepted the hash → printed `11.9.0` (a wrong hash would make corepack refuse to run).
- `pnpm install --frozen-lockfile` still passes with no lockfile drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEP5DMkpLUNXC4SBGQxq8i

---
_Generated by [Claude Code](https://claude.ai/code/session_01PEP5DMkpLUNXC4SBGQxq8i)_