### PR TITLE
fix(ci): drop China npm mirror so Vercel install can reach registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 shamefully-hoist=true
-registry=https://registry.npmmirror.com/


### PR DESCRIPTION
`.npmrc` forced `registry.npmmirror.com`, which Vercel's build infrastructure cannot reach reliably, causing `fetch failed` during `pnpm install` and breaking the deployment. The lockfile pins packages by integrity hash (no mirror URLs baked in), so falling back to the default `registry.npmjs.org` resolves identical versions.

Verified locally: `pnpm install --frozen-lockfile` and `pnpm run build` (vite-ssg) both succeed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EC3y3c1wYjJjAwjNH5sBkD)_