### PR TITLE
fix(ci): enable Corepack on Vercel so it uses pinned pnpm 11

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,11 @@
 {
-  "redirects": [
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "build": {
+    "env": {
+      "ENABLE_EXPERIMENTAL_COREPACK": "1"
+    }
+  },
+  "rewrites": [
     {
       "source": "/(.*)",
       "destination": "/index.html"


### PR DESCRIPTION
## Why the deploy still failed

Vercel build log:
```
Detected `pnpm-lock.yaml` 9 ... Using pnpm@9.x based on project creation date
ERROR  packages field missing or empty
Error: Command "pnpm install" exited with 1
```

Vercel defaulted to **pnpm@9.x** (ignoring the `packageManager: pnpm@11.9.0` pin), and pnpm 9 rejects the settings-only `pnpm-workspace.yaml` (no `packages:` field) with *"packages field missing or empty"*. pnpm 11 tolerates it, which is why local/CI builds pass.

## Fix

- Set `ENABLE_EXPERIMENTAL_COREPACK=1` in `vercel.json` build env so Vercel honors the integrity-hashed `packageManager` pin and runs pnpm 11 — consistent with local and GitHub Actions.
- Switch the SPA fallback from `redirects` → `rewrites`. The redirect rule issued an HTTP redirect for *every* path (including assets and the per-route HTML files `vite-ssg` now emits), which would break the deployed site. `rewrites` only apply to paths with no matching static file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EC3y3c1wYjJjAwjNH5sBkD)_